### PR TITLE
Change editorGroupHeader color

### DIFF
--- a/theme/alabaster-color-theme.json
+++ b/theme/alabaster-color-theme.json
@@ -97,6 +97,7 @@
 		"editor.selectionHighlightBackground": "#E0E0E0",
 		"panel.background": "#F0F0F0",
 		"sideBar.background": "#F0F0F0",
+		"editorGroupHeader.tabsBackground":"#F0F0F0",
 		"activityBar.background": "#F0F0F0",
 		"activityBar.foreground": "#007ACC",
 		"editorLineNumber.foreground": "#9DA39A",


### PR DESCRIPTION
Make tabs' bar background color the same as sideBar/activityBar/menuBar
for the sake of consistency.