### PR TITLE
fix selection of highlighted by search

### DIFF
--- a/theme/alabaster-color-theme.json
+++ b/theme/alabaster-color-theme.json
@@ -104,7 +104,7 @@
 		"editorLineNumber.foreground": "#9DA39A",
 		"editorCursor.foreground": "#007ACC",
 		"editor.findMatchBackground": "#FFBC5D",
-		"editor.findMatchHighlightBackground": "#FFE9A6",
+		"editor.findMatchHighlightBackground": "#FFDF80B1",
 		"statusBar.background" : "#DDDDDD",
     "statusBar.foreground": "#474747",
 		"statusBar.debuggingBackground": "#FFBC5D",


### PR DESCRIPTION
Hello! I've added transparency to "editor.findMatchHighlightBackground". It allows selection to be visible.

Before:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/2579623/119231214-51c6c880-bb28-11eb-91b5-477d5fe06e52.png">

After:

<img width="920" alt="image" src="https://user-images.githubusercontent.com/2579623/119231218-59866d00-bb28-11eb-98fe-69cfecd7b660.png">

Thank you!