### PR TITLE
Fix Quick Pick & suggest widget colors

### DIFF
--- a/theme/alabaster-color-theme.json
+++ b/theme/alabaster-color-theme.json
@@ -112,6 +112,10 @@
 		"statusBar.noFolderBackground": "#7A3E9D",
 		"statusBar.noFolderForeground": "#fff",
 
+		"list.focusHighlightForeground": "#F7F7F7",
+		"quickInputList.focusForeground": "#F7F7F7",
+		"editorSuggestWidget.selectedForeground":"#F7F7F7",
+
 		"terminal.ansiWhite": "#BBBBBB",
     "terminal.ansiBlack": "#000000",
     "terminal.ansiBlue": "#325CC0",


### PR DESCRIPTION
New color tokens [has been added](https://code.visualstudio.com/updates/v1_57#_updated-quick-pick-suggest-widget-colors) in VS Code 1.57 and without specifying their colors they blend in with the background

Before
![before](https://user-images.githubusercontent.com/31551638/121682430-c4dab380-cac4-11eb-8169-bddb3451a8ef.png)
![before2](https://user-images.githubusercontent.com/31551638/121682667-08352200-cac5-11eb-8b8b-bcf81d1078d3.png)


After
![after](https://user-images.githubusercontent.com/31551638/121682585-efc50780-cac4-11eb-9814-7c202e4980aa.png)
![after2](https://user-images.githubusercontent.com/31551638/121683078-901b2c00-cac5-11eb-98f5-9a279280796a.png)


