### PR TITLE
Suggest widget colouring

### DIFF
--- a/theme/alabaster-color-theme.json
+++ b/theme/alabaster-color-theme.json
@@ -1,7 +1,9 @@
-{ "$schema": "vscode://schemas/color-theme",
-  "name": "Alabaster",
-  "tokenColors": [
-    { "name": "Comments",
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Alabaster",
+	"tokenColors": [
+		{
+			"name": "Comments",
 			"scope": [
 				"comment",
 				"punctuation.definition.comment"
@@ -10,7 +12,8 @@
 				"foreground": "#AA3731"
 			}
 		},
-		{ "name": "Strings",
+		{
+			"name": "Strings",
 			"scope": [
 				"string",
 				"string.regexp",
@@ -46,7 +49,7 @@
 				"foreground": "#325CC0"
 			}
 		},
-	  {
+		{
 			"name": "Punctuation",
 			"scope": "punctuation",
 			"settings": {
@@ -89,7 +92,7 @@
 				"foreground": "#434343"
 			}
 		}
-  ],
+	],
 	"colors": {
 		"editor.background": "#F7F7F7",
 		"editor.foreground": "#000",
@@ -98,15 +101,15 @@
 		"editor.selectionHighlightBackground": "#E0E0E0",
 		"panel.background": "#F0F0F0",
 		"sideBar.background": "#F0F0F0",
-		"editorGroupHeader.tabsBackground":"#F0F0F0",
+		"editorGroupHeader.tabsBackground": "#F0F0F0",
 		"activityBar.background": "#F0F0F0",
 		"activityBar.foreground": "#007ACC",
 		"editorLineNumber.foreground": "#9DA39A",
 		"editorCursor.foreground": "#007ACC",
 		"editor.findMatchBackground": "#FFBC5D",
 		"editor.findMatchHighlightBackground": "#FFDF80B1",
-		"statusBar.background" : "#DDDDDD",
-    "statusBar.foreground": "#474747",
+		"statusBar.background": "#DDDDDD",
+		"statusBar.foreground": "#474747",
 		"statusBar.debuggingBackground": "#FFBC5D",
 		"statusBar.debuggingForeground": "#000",
 		"statusBar.noFolderBackground": "#7A3E9D",
@@ -114,23 +117,23 @@
 
 		"list.focusHighlightForeground": "#F7F7F7",
 		"quickInputList.focusForeground": "#F7F7F7",
-		"editorSuggestWidget.selectedForeground":"#F7F7F7",
+		"editorSuggestWidget.selectedForeground": "#F7F7F7",
 
 		"terminal.ansiWhite": "#BBBBBB",
-    "terminal.ansiBlack": "#000000",
-    "terminal.ansiBlue": "#325CC0",
-    "terminal.ansiCyan": "#0083B2",
-    "terminal.ansiGreen": "#448C27",
-    "terminal.ansiMagenta": "#7A3E9D",
-    "terminal.ansiRed": "#AA3731",
-    "terminal.ansiYellow": "#CB9000",
-    "terminal.ansiBrightWhite": "#FFFFFF",
-    "terminal.ansiBrightBlack": "#777777",
-    "terminal.ansiBrightBlue": "#007ACC",
-    "terminal.ansiBrightCyan": "#00AACB",
-    "terminal.ansiBrightGreen": "#60CB00",
-    "terminal.ansiBrightMagenta": "#E64CE6",
-    "terminal.ansiBrightRed": "#F05050",
-    "terminal.ansiBrightYellow": "#FFBC5D"
-  }
+		"terminal.ansiBlack": "#000000",
+		"terminal.ansiBlue": "#325CC0",
+		"terminal.ansiCyan": "#0083B2",
+		"terminal.ansiGreen": "#448C27",
+		"terminal.ansiMagenta": "#7A3E9D",
+		"terminal.ansiRed": "#AA3731",
+		"terminal.ansiYellow": "#CB9000",
+		"terminal.ansiBrightWhite": "#FFFFFF",
+		"terminal.ansiBrightBlack": "#777777",
+		"terminal.ansiBrightBlue": "#007ACC",
+		"terminal.ansiBrightCyan": "#00AACB",
+		"terminal.ansiBrightGreen": "#60CB00",
+		"terminal.ansiBrightMagenta": "#E64CE6",
+		"terminal.ansiBrightRed": "#F05050",
+		"terminal.ansiBrightYellow": "#FFBC5D"
+	}
 }

--- a/theme/alabaster-color-theme.json
+++ b/theme/alabaster-color-theme.json
@@ -117,7 +117,11 @@
 
 		"list.focusHighlightForeground": "#F7F7F7",
 		"quickInputList.focusForeground": "#F7F7F7",
-		"editorSuggestWidget.selectedForeground": "#F7F7F7",
+		
+		"editorSuggestWidget.selectedBackground": "#CCCCCC",
+		"editorSuggestWidget.focusHighlightForeground": "#000000",
+		"editorSuggestWidget.highlightForeground": "#000000",
+		"editorSuggestWidget.selectedForeground": "#000000",
 
 		"terminal.ansiWhite": "#BBBBBB",
 		"terminal.ansiBlack": "#000000",


### PR DESCRIPTION
Hello!

I've fixed visibility in suggest widget and made colors similar to Alabaster theme in Sublime Text.

Before:
<img width="930" alt="image" src="https://user-images.githubusercontent.com/2579623/124244294-78185480-db27-11eb-8f97-538262e9b7fd.png">

After:
<img width="917" alt="image" src="https://user-images.githubusercontent.com/2579623/124244322-7ea6cc00-db27-11eb-8275-b1edd6aee19c.png">

Sublime Text:
<img width="379" alt="image" src="https://user-images.githubusercontent.com/2579623/124244345-85354380-db27-11eb-8bd1-214a3cc4b6dc.png">

Thank you!
