### PR TITLE
make consistent colors in panels

### DIFF
--- a/theme/alabaster-color-theme.json
+++ b/theme/alabaster-color-theme.json
@@ -115,10 +115,16 @@
 		"statusBar.noFolderBackground": "#7A3E9D",
 		"statusBar.noFolderForeground": "#fff",
 
-		"list.focusHighlightForeground": "#F7F7F7",
-		"quickInputList.focusForeground": "#F7F7F7",
-		
-		"editorSuggestWidget.selectedBackground": "#CCCCCC",
+		"list.activeSelectionBackground": "#DDDDDD",
+		"list.activeSelectionForeground": "#000000",
+		"list.inactiveSelectionBackground": "#E6E6E6",
+		"list.focusHighlightForeground": "#007ACC",
+		"focusBorder": "#CCCCCC",
+
+		"quickInputList.focusForeground": "#000000",
+		"quickInputList.focusBackground": "#DDDDDD",
+
+		"editorSuggestWidget.selectedBackground": "#DDDDDD",
 		"editorSuggestWidget.focusHighlightForeground": "#000000",
 		"editorSuggestWidget.highlightForeground": "#000000",
 		"editorSuggestWidget.selectedForeground": "#000000",


### PR DESCRIPTION
Hello! I've tried to make panels to look uniformly.

Side Bar:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/2579623/124349698-4a034500-dbf9-11eb-91cb-f9f298de1746.png">

Quick Input:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/2579623/124349733-6b643100-dbf9-11eb-8b6f-25de6a15108b.png">

Suggest Widget:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/2579623/124349761-82a31e80-dbf9-11eb-8f00-67de8a787936.png">

Thank you!