### PR TITLE
Selection highlight background is opaque

### DIFF
--- a/theme/alabaster-color-theme.json
+++ b/theme/alabaster-color-theme.json
@@ -107,7 +107,7 @@
 		"editorLineNumber.foreground": "#9DA39A",
 		"editorCursor.foreground": "#007ACC",
 		"editor.findMatchBackground": "#FFBC5D",
-		"editor.findMatchHighlightBackground": "#FFDF80B1",
+		"editor.findMatchHighlightBackground": "#FFD86381",
 		"statusBar.background": "#DDDDDD",
 		"statusBar.foreground": "#474747",
 		"statusBar.debuggingBackground": "#FFBC5D",

--- a/theme/alabaster-color-theme.json
+++ b/theme/alabaster-color-theme.json
@@ -98,7 +98,7 @@
 		"editor.foreground": "#000",
 		"editor.lineHighlightBackground": "#F0F0F0",
 		"editor.selectionBackground": "#BFDBFE",
-		"editor.selectionHighlightBackground": "#E0E0E0",
+		"editor.selectionHighlightBackground": "#CFCFCF81",
 		"panel.background": "#F0F0F0",
 		"sideBar.background": "#F0F0F0",
 		"editorGroupHeader.tabsBackground": "#F0F0F0",


### PR DESCRIPTION
Hello! One more little thing :)

Before (selection invisible):
<img width="413" alt="image" src="https://user-images.githubusercontent.com/2579623/124630070-b9dc2e80-de8a-11eb-9b05-ee1554ec7af2.png">

After:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/2579623/124630046-b3e64d80-de8a-11eb-912e-42dad7a5cd10.png">

Thank you!
