### PR TITLE
Add description field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "theme-alabaster",
+	"description": "A light theme with minimal amount of highlighting",
 	"displayName": "Alabaster Theme",
 	"version": "0.2.9",
 	"publisher": "tonsky",


### PR DESCRIPTION
The description field is a standard package.json field that almost all VSCode extensions have. Other tools may assume it exists.