### PR TITLE
README: Add extension url in install to help distinguish from variant extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Additionally:
 2. Search for `alabaster`
 3. Install
 
+Or alternatively open the extension webpage in browser and install from there: https://marketplace.visualstudio.com/items?itemName=tonsky.theme-alabaster
+
 ## License
 
 [MIT License](https://github.com/tonsky/vscode-theme-alabaster/blob/master/./LICENSE.txt)


### PR DESCRIPTION
When searching for "alabaster" in VS Code, several extension variants show.  Prominently adding extension url in install in Github helps users know which is the correct extension to install.

For example, top 5 extension search results for "alabaster" in VS Code all mention "Alabaster" word as they are variants:

<img width="358" height="541" alt="image" src="https://github.com/user-attachments/assets/9f1aa34a-2512-4367-b71c-8d84fd1483d6" />

Additionally it would be good if the repo author could also add this VS Code extension url in Github's repo settings to make the link easier to find.